### PR TITLE
Fix Overlapping User Entries in Pagination for list_users Endpoint

### DIFF
--- a/app/routers/user_routes.py
+++ b/app/routers/user_routes.py
@@ -176,7 +176,7 @@ async def list_users(
     current_user: dict = Depends(require_role(["ADMIN", "MANAGER"]))
 ):
     total_users = await UserService.count(db)
-    users = await UserService.list_users(db, skip, limit)
+    users = await UserService.list_users(db, skip * limit, limit)
 
     user_responses = [
         UserResponse.model_validate(user) for user in users
@@ -188,7 +188,7 @@ async def list_users(
     return UserListResponse(
         items=user_responses,
         total=total_users,
-        page=skip // limit + 1,
+        page=skip + 1,
         size=len(user_responses),
         links=pagination_links  # Ensure you have appropriate logic to create these links
     )


### PR DESCRIPTION
## Description
This pull request addresses an issue with the `list_users` endpoint where user entries were overlapping across different pages. The fix ensures that each user appears only once across the paginated results and that the pagination logic correctly calculates the current page.

## Changes Made
- Updated the `list_users` endpoint to correctly calculate the `skip` value, preventing overlapping user entries.
- Adjusted the `page` calculation to accurately reflect the current page based on the `skip` value.
