### PR TITLE
User Deletion Process Does Not Return Detailed Response Body

### DIFF
--- a/app/routers/user_routes.py
+++ b/app/routers/user_routes.py
@@ -22,6 +22,7 @@ from builtins import dict, int, len, str
 from datetime import timedelta
 from uuid import UUID
 from fastapi import APIRouter, Depends, HTTPException, Response, status, Request
+from fastapi.responses import JSONResponse
 from fastapi.security import OAuth2PasswordBearer, OAuth2PasswordRequestForm
 from sqlalchemy.ext.asyncio import AsyncSession
 from app.dependencies import get_current_user, get_db, get_email_service, require_role
@@ -107,20 +108,18 @@ async def update_user(user_id: UUID, user_update: UserUpdate, request: Request, 
         updated_at=updated_user.updated_at,
         links=create_user_links(updated_user.id, request)
     )
-
-
-@router.delete("/users/{user_id}", status_code=status.HTTP_204_NO_CONTENT, name="delete_user", tags=["User Management Requires (Admin or Manager Roles)"])
+@router.delete("/users/{user_id}", status_code=status.HTTP_200_OK, name="delete_user", tags=["User Management Requires (Admin or Manager Roles)"])
 async def delete_user(user_id: UUID, db: AsyncSession = Depends(get_db), token: str = Depends(oauth2_scheme), current_user: dict = Depends(require_role(["ADMIN", "MANAGER"]))):
     """
     Delete a user by their ID.
 
     - **user_id**: UUID of the user to delete.
     """
+    user = await UserService.get_by_id(db, user_id)
     success = await UserService.delete(db, user_id)
     if not success:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
-
+    return JSONResponse(content={"detail": f"User '{user_id}' with nickname '{user.nickname}' deleted"}, status_code=status.HTTP_200_OK)
 
 
 @router.post("/users/", response_model=UserResponse, status_code=status.HTTP_201_CREATED, tags=["User Management Requires (Admin or Manager Roles)"], name="create_user")

--- a/tests/test_api/test_users_api.py
+++ b/tests/test_api/test_users_api.py
@@ -56,7 +56,7 @@ async def test_update_user_email_access_allowed(async_client, admin_user, admin_
 async def test_delete_user(async_client, admin_user, admin_token):
     headers = {"Authorization": f"Bearer {admin_token}"}
     delete_response = await async_client.delete(f"/users/{admin_user.id}", headers=headers)
-    assert delete_response.status_code == 204
+    assert delete_response.status_code == 200
     # Verify the user is deleted
     fetch_response = await async_client.get(f"/users/{admin_user.id}", headers=headers)
     assert fetch_response.status_code == 404


### PR DESCRIPTION
## Description
The `delete_user` endpoint has been updated to enhance user-friendliness by changing the response code from 204 No Content to 200 OK. Additionally, the response body now includes the ID and nickname of the deleted user, providing clear confirmation of the deletion.

## Changes Made to the Code
- Endpoint Change:
- Updated the `delete_user` endpoint to fetch the user details before deletion.
- Changed the status code to `200 OK`.
- Included the ID and nickname of the deleted user in the response body.